### PR TITLE
Add minimal Python project setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+
+jobs:
+  lint_and_test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+      - name: Install deps
+        run: |
+          python -m pip install -U pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          pip install pytest
+      - name: Run pre-commit (black/isort/ruff)
+        uses: pre-commit/action@v3.0.1
+      - name: Run tests
+        env:
+          PYTHONPATH: src
+        run: pytest -q

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+__pycache__/
+*.py[cod]
+.venv/
+.env
+.env.local
+*.egg-info/
+.pytest_cache/
+
+# Editors
+.vscode/
+.idea/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 24.3.0
+    hooks:
+      - id: black
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.13.2
+    hooks:
+      - id: isort
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.3.5
+    hooks:
+      - id: ruff

--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
-# Hi there
-## About me
+# Blue Ocean
+
+Minimal Python project demonstrating a simple `hello` function.
+
+## Development
+
+Install dependencies and activate pre-commit:
+
+```bash
+pip install -e .
+pre-commit install
+```
+
+Run tests with `pytest`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,20 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "blue_ocean"
+version = "0.1.0"
+description = "Minimal Python project."
+readme = "README.md"
+requires-python = ">=3.11"
+
+[tool.black]
+line-length = 88
+
+[tool.isort]
+profile = "black"
+
+[tool.ruff]
+line-length = 88
+select = ["E", "F", "I"]

--- a/src/blue_ocean/__init__.py
+++ b/src/blue_ocean/__init__.py
@@ -1,0 +1,1 @@
+"""Blue Ocean package."""

--- a/src/blue_ocean/hello.py
+++ b/src/blue_ocean/hello.py
@@ -1,0 +1,6 @@
+"""Sample hello module."""
+
+
+def say_hello() -> str:
+    """Return a friendly greeting."""
+    return "Hello, World!"

--- a/tests/test_hello.py
+++ b/tests/test_hello.py
@@ -1,0 +1,5 @@
+from blue_ocean.hello import say_hello
+
+
+def test_say_hello():
+    assert say_hello() == "Hello, World!"


### PR DESCRIPTION
## Summary
- add sample hello module under src/blue_ocean
- configure pyproject with black, isort and ruff
- include pre-commit config and pytest example

## Testing
- `PYTHONPATH=src pytest -q`
- `pre-commit run --files src/blue_ocean/__init__.py src/blue_ocean/hello.py tests/test_hello.py pyproject.toml README.md .gitignore .pre-commit-config.yaml` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a65d1d5e84832ba149ed61f29e4ba8